### PR TITLE
Create send middleware.

### DIFF
--- a/src/middleware/render.js
+++ b/src/middleware/render.js
@@ -13,7 +13,13 @@ export default ({
     handler(...params, store);
 
     Promise.resolve(render(req, res, store))
-      .catch((err) => app.error(err, req, res));
+      .then((result) => {
+        res.render = result;
+        res.body = result.markup;
+      })
+      .catch((err) => {
+        app.error(err, req, res);
+      });
   };
 
   return {

--- a/src/middleware/send.js
+++ b/src/middleware/send.js
@@ -1,0 +1,12 @@
+import isFunction from 'lodash/isFunction';
+
+export default (body = (req) => req.body) => (app) => {
+  const getBody = isFunction(body) ? body : () => body;
+
+  return {
+    ...app,
+    request(req, res) {
+      res.end(getBody(req));
+    },
+  };
+};

--- a/test/spec/middleware/send.spec.js
+++ b/test/spec/middleware/send.spec.js
@@ -1,0 +1,18 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import send from '../../../src/middleware/send';
+
+it('should call `res.end` with `res.body`', () => {
+  const end = sinon.spy();
+  const app = send()();
+  app.request({ body: 'test' }, { end });
+  expect(end).to.be.calledWith('test');
+});
+
+it('should call `res.end` with constant value', () => {
+  const end = sinon.spy();
+  const app = send('test')();
+  app.request({}, { end });
+  expect(end).to.be.calledWith('test');
+});


### PR DESCRIPTION
Render middleware is no longer responsible for calling `res.end`.