### PR TITLE
Adapters.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 *.js
 middleware/**/*
+adapter/**/*
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ node_modules
 build
 /*.js
 /middleware
+/adapter
 coverage

--- a/README.md
+++ b/README.md
@@ -63,22 +63,12 @@ In that sense http middleware is even less opinionated than [express] middleware
 ### With `http`
 
 ```javascript
-import compose from 'lodash/function/compose';
 import http from 'http';
-
+import connect from 'http-middleware-metalab/adapter/http';
 import base from 'http-middleware-metalab/base';
-import webpack from 'http-middleware-metalab/webpack';
 
 const server = http.createServer();
-const createApp = compose(
-  base({
-    locales: [ 'en-US' ],
-  }),
-  webpack({
-    assets: '/assets',
-  })
-);
-
+const createApp = base();
 const app = createApp({
   request(req, res) {
     res.statusCode = 200;
@@ -89,46 +79,37 @@ const app = createApp({
   },
 });
 
-server.on('request', app.request);
-server.on('error', app.error);
-
-server.listen(8080);
+connect(app, server).listen(8080);
 ```
 
 ### With `express`
 
 ```javascript
-import compose from 'lodash/function/compose';
-import http from 'http';
-
+import express from 'express';
+import connector from 'http-middleware-metalab/adapter/express';
 import base from 'http-middleware-metalab/base';
-import webpack from 'http-middleware-metalab/webpack';
 
-const createMiddleware = compose(
-  base({
-    locales: [ 'en-US' ],
-  }),
-  webpack({
-    assets: '/assets',
-  })
-);
-
+const createMiddleware = base();
 const app = express();
 
-app.use((req, res, next) => {
-  const middleware = createMiddleware({
-    error: next,
-    request: () => next(),
-  });
-  middleware.request(req, res);
-});
-
+app.use(connector(createMiddleware));
 app.listen(8080);
 ```
 
 ### With `hapi`
 
-TODO: Figure this out.
+```javascript
+import { Server } from 'hapi';
+import connector from 'http-middleware-metalab/adapter/hapi';
+import base from 'http-middleware-metalab/base';
+
+const createMiddleware = base();
+const server = new Server();
+
+server.connection({ port: 8080 });
+server.ext(connector(createMiddleware));
+server.start();
+```
 
 [http]: https://nodejs.org/api/http.html
 [hapi]: http://hapijs.com/

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.1",
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "license": "CC0-1.0",
+  "repository": "metalabdesign/http-middleware-metalab",
   "main": "index.js",
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s inline -d . ./src --source-maps true",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s inline -d . ./src --source-maps true",
     "test": "npm run lint && npm run spec",
-    "spec": "NODE_ENV=test ./node_modules/.bin/_mocha --recursive -r test/helpers/chai.js -r adana-dump --compilers js:babel-core/register -R spec test/spec",
+    "spec": "NODE_ENV=test ./test/script/spec.sh",
     "lint": "eslint ."
   },
   "dependencies": {
@@ -31,11 +31,14 @@
     "babel-core": "^6.3.26",
     "babel-preset-metalab": "^0.1.4",
     "chai": "^3.4.1",
+    "chai-http": "^1.0.0",
     "eslint": "^1.10.3",
     "eslint-config-metalab": "^1.0.0-rc.4",
     "eslint-plugin-filenames": "^0.2.0",
     "eslint-plugin-import": "^0.11.0",
     "eslint-plugin-react": "^3.11.2",
+    "express": "^4.13.4",
+    "hapi": "^12.1.0",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"

--- a/src/adapter/express.js
+++ b/src/adapter/express.js
@@ -1,0 +1,10 @@
+
+export default function express(createMiddleware) {
+  return (req, res, next) => {
+    const middleware = createMiddleware({
+      error: next,
+      request: () => next(),
+    });
+    middleware.request(req, res);
+  };
+}

--- a/src/adapter/express.js
+++ b/src/adapter/express.js
@@ -1,10 +1,16 @@
-
 export default function express(createMiddleware) {
+  const middleware = createMiddleware({
+    error: (err, req) => {
+      if (req) {
+        req.__next(err);
+      }
+    },
+    request: (req) => {
+      req.__next();
+    },
+  });
   return (req, res, next) => {
-    const middleware = createMiddleware({
-      error: next,
-      request: () => next(),
-    });
+    req.__next = next;
     middleware.request(req, res);
   };
 }

--- a/src/adapter/hapi.js
+++ b/src/adapter/hapi.js
@@ -1,0 +1,14 @@
+
+export default function hapi(createMiddleware) {
+  return {
+    type: 'onRequest',
+    method: (request, reply) => {
+      const { req, res } = request.raw;
+      const middleware = createMiddleware({
+        request: () => reply.continue(),
+        error: (err) => reply(err),
+      });
+      middleware.request(req, res);
+    },
+  };
+}

--- a/src/adapter/hapi.js
+++ b/src/adapter/hapi.js
@@ -1,13 +1,17 @@
-
 export default function hapi(createMiddleware) {
+  const middleware = createMiddleware({
+    request: (req) => req.__reply.continue(),
+    error: (err, req) => {
+      if (req) {
+        req.__reply(err);
+      }
+    },
+  });
   return {
     type: 'onRequest',
     method: (request, reply) => {
       const { req, res } = request.raw;
-      const middleware = createMiddleware({
-        request: () => reply.continue(),
-        error: (err) => reply(err),
-      });
+      req.__reply = reply;
       middleware.request(req, res);
     },
   };

--- a/src/adapter/http.js
+++ b/src/adapter/http.js
@@ -1,0 +1,6 @@
+export default function connect(app, server) {
+  Object.keys(app).forEach(evt => {
+    server.on(evt, app[evt]);
+  });
+  return server;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,5 @@
 import base from './base';
 import webpack from './webpack';
+import connect from './adapter/http';
 
-export function connect(app, server) {
-  Object.keys(app).forEach(evt => {
-    server.on(evt, app[evt]);
-  });
-  return server;
-}
-
-export { base, webpack };
+export { connect, base, webpack };

--- a/test/helpers/chai.js
+++ b/test/helpers/chai.js
@@ -1,4 +1,6 @@
 import chai from 'chai';
 import sinon from 'sinon-chai';
+import http from 'chai-http';
 
 chai.use(sinon);
+chai.use(http);

--- a/test/script/spec.sh
+++ b/test/script/spec.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+OPTS="-r test/helpers/chai.js -r adana-dump --compilers js:babel-core/register -R spec"
+SPECS="test/spec/**/*.spec.js"
+
+# Check for stupid HAPI
+echo '"use strict"; const i = 1;' | node > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+  SPECS="test/spec/**/!(*hapi*).spec.js"
+fi
+
+set -x
+./node_modules/.bin/_mocha ${OPTS} ${SPECS}

--- a/test/spec/adapter/express.spec.js
+++ b/test/spec/adapter/express.spec.js
@@ -1,0 +1,32 @@
+import { request, expect } from 'chai';
+import http from 'http';
+import express from 'express';
+import base from '../../../src/base';
+import connector from '../../../src/adapter/express';
+
+const createMiddleware = base();
+
+describe('express', () => {
+  let app;
+  let server;
+
+  beforeEach(done => {
+    app = express();
+    app.use(connector(createMiddleware));
+    app.get('/', (req, res) => res.status(200).send());
+    server = http.createServer(app);
+    server.listen(done);
+  });
+
+  afterEach(done => {
+    server.close(done);
+    app = null;
+    server = null;
+  });
+
+  it('should return a result', () => {
+    return request(server).get('/').then(res => {
+      expect(res).to.have.status(200);
+    });
+  });
+});

--- a/test/spec/adapter/hapi.spec.js
+++ b/test/spec/adapter/hapi.spec.js
@@ -1,0 +1,35 @@
+import { request, expect } from 'chai';
+import { Server } from 'hapi';
+import base from '../../../src/base';
+import connector from '../../../src/adapter/hapi';
+
+const createMiddleware = base();
+
+describe('hapi', () => {
+  let server;
+
+  beforeEach(done => {
+    server = new Server();
+    server.connection({ host: 'localhost', port: 0, compression: false });
+    server.ext(connector(createMiddleware));
+    server.address = () => server.info;
+    server.route({
+      method: 'GET',
+      path: '/',
+      handler(request, reply) {
+        reply('Hello, world!');
+      },
+    });
+    server.start(done);
+  });
+
+  afterEach(done => {
+    server.stop(done);
+  });
+
+  it('should return a result', () => {
+    return request(server).get('/').then(res => {
+      expect(res).to.have.status(200);
+    });
+  });
+});

--- a/test/spec/adapter/http.spec.js
+++ b/test/spec/adapter/http.spec.js
@@ -1,0 +1,29 @@
+import { request, expect } from 'chai';
+import { createServer } from 'http';
+import base from '../../../src/base';
+import connect from '../../../src/adapter/http';
+
+const createMiddleware = base();
+
+describe('http', () => {
+  // Create a server with a host and port
+  let server;
+
+  beforeEach(done => {
+    server = createServer();
+    connect(createMiddleware({
+      request: (req, res) => res.end(),
+    }), server).listen(done);
+  });
+
+  afterEach(done => {
+    server.close(done);
+    server = null;
+  });
+
+  it('should return a result', () => {
+    return request(server).get('/').then(res => {
+      expect(res).to.have.status(200);
+    });
+  });
+});

--- a/test/spec/middleware/empty.spec.js
+++ b/test/spec/middleware/empty.spec.js
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import empty from '../../../src/middleware/empty';
+
+it('should `404` by default', () => {
+  const spy = sinon.spy();
+  const res = { end: spy };
+  const app = empty();
+  app.request({}, res);
+  expect(res).to.have.property('statusCode', 404);
+});
+
+it('should throw errors it encounters', () => {
+  const app = empty();
+  expect(() => {
+    app.error(new Error());
+  }).to.throw(Error);
+});

--- a/test/spec/middleware/graceful.spec.js
+++ b/test/spec/middleware/graceful.spec.js
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import graceful from '../../../src/middleware/graceful';
+
+it('should 502 when server is shutting down', () => {
+  const stub = sinon.stub();
+  const spy = sinon.spy();
+  const app = graceful()({ request: spy });
+  const res = { setHeader: stub, end: stub };
+  app.request({ socket: { _handle: null }}, res);
+  expect(res).to.have.property('statusCode', 502);
+  expect(spy).not.to.be.called;
+});


### PR DESCRIPTION
Connect with more than just `http`; now initial support for `express` and `hapi`. It made sense to include first-class functionality for doing this since it will probably be a common pattern and will make migration easier.

Special updates to the test scripts had to be made for `hapi` since it doesn't support `node@0.12`. When this case is detected, the `hapi` tests are not run.