### PR TITLE
Add option to set `Content-Type` header to `send`.

### DIFF
--- a/src/middleware/send.js
+++ b/src/middleware/send.js
@@ -1,11 +1,17 @@
 import isFunction from 'lodash/isFunction';
 
-export default (body = (req) => req.body) => (app) => {
+export default ({
+  body = (req) => req.body,
+  type = () => 'text/html; charset=utf-8',
+} = {}) => (app) => {
   const getBody = isFunction(body) ? body : () => body;
+  const getType = isFunction(type) ? type : () => type;
 
   return {
     ...app,
     request(req, res) {
+      const contentType = getType(req);
+      contentType && res.setHeader('Content-Type', getType(req));
       res.end(getBody(req));
     },
   };

--- a/test/spec/middleware/send.spec.js
+++ b/test/spec/middleware/send.spec.js
@@ -3,16 +3,47 @@ import sinon from 'sinon';
 
 import send from '../../../src/middleware/send';
 
-it('should call `res.end` with `res.body`', () => {
-  const end = sinon.spy();
-  const app = send()();
-  app.request({ body: 'test' }, { end });
-  expect(end).to.be.calledWith('test');
+describe('send', () => {
+  let res;
+  let req;
+
+  beforeEach(() => {
+    req = { body: 'body' };
+    res = {
+      end: sinon.spy(),
+      setHeader: sinon.spy(),
+    };
+  });
+
+  it('should call `res.end` with `res.body`', () => {
+    const app = send()();
+    app.request(req, res);
+    expect(res.setHeader).to.be
+      .calledWith('Content-Type', 'text/html; charset=utf-8');
+    expect(res.end).to.be.calledWith(req.body);
+  });
+
+  it('should call `res.end` with constant value', () => {
+    const app = send({ body: 'constant' })();
+    app.request(req, res);
+    expect(res.setHeader).to.be
+      .calledWith('Content-Type', 'text/html; charset=utf-8');
+    expect(res.end).to.be.calledWith('constant');
+  });
+
+  it('should set `Content-Type` header with constant value', () => {
+    const app = send({ type: 'constant' })();
+    app.request(req, res);
+    expect(res.setHeader).to.be
+      .calledWith('Content-Type', 'constant');
+    expect(res.end).to.be.calledWith('body');
+  });
+
+  it('should not set `Content-Type` header if type is falsy', () => {
+    const app = send({ type: false })();
+    app.request(req, res);
+    expect(res.setHeader).not.to.have.been.called;
+    expect(res.end).to.be.calledWith('body');
+  });
 });
 
-it('should call `res.end` with constant value', () => {
-  const end = sinon.spy();
-  const app = send('test')();
-  app.request({}, { end });
-  expect(end).to.be.calledWith('test');
-});


### PR DESCRIPTION
Breaking change to `send` arguments.
```js
// Before
send((req) => req.body),

// Affer
send({ body: (req) => req.body }),
```