### PR TITLE
Minimal header middleware.

### DIFF
--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -1,0 +1,18 @@
+import isFunction from 'lodash/isFunction';
+
+export default (header, getValue) => (app) => {
+  const finalGetValue = isFunction(getValue) ? getValue : () => getValue;
+  return {
+    ...app,
+    request(req, res) {
+      return Promise.resolve(req)
+        .then(finalGetValue)
+        .then((value) => {
+          value && res.setHeader(header, value);
+          app.request(req, res);
+        })
+        .catch((err) => app.error(err, req, res));
+    },
+  };
+};
+

--- a/test/spec/middleware/header.spec.js
+++ b/test/spec/middleware/header.spec.js
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import header from '../../../src/middleware/header';
+
+describe('header', () => {
+  let res;
+  let req;
+  let next;
+
+  beforeEach(() => {
+    req = {};
+    res = {
+      setHeader: sinon.spy(),
+    };
+    next = {
+      request: sinon.spy(),
+      error: sinon.spy(),
+    };
+  });
+
+  it('should call next request', (done) => {
+    const app = header()(next);
+    app.request(req, res).then(() => {
+      expect(next.request).to.be.calledWith(req, res);
+      done();
+    });
+  });
+
+  it('should call res.setHeader', (done) => {
+    const app = header('foo', 'bar')(next);
+    app.request(req, res).then(() => {
+      expect(res.setHeader).to.be.calledWith('foo', 'bar');
+      done();
+    });
+  });
+
+  it('should call function argument', (done) => {
+    const handler = sinon.spy(() => 'bar');
+    const app = header('foo', handler)(next);
+    app.request(req, res).then(() => {
+      expect(handler).to.be.calledWith(req);
+      expect(res.setHeader).to.be.calledWith('foo', 'bar');
+      done();
+    });
+  });
+
+  it('should not call setHeader if value is falsy', (done) => {
+    const app = header('foo', false)(next);
+    app.request(req, res).then(() => {
+      expect(res.setHeader).to.not.have.been.called;
+      done();
+    });
+  });
+
+  it('should call next error', (done) => {
+    const err = new Error();
+    const handler = () => {
+      throw err;
+    };
+    const app = header('foo', handler)(next);
+    app.request(req, res).then(() => {
+      expect(next.error).to.be.calledWith(err, req, res);
+      expect(res.setHeader).to.not.have.been.called;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Takes two arguments, header name, and value. Value can be a string, a promise, or a function that operates on `req` and returns a string or promise. If a falsy value is returned, header is not set.