### PR TITLE
Minimal status code middleware.

### DIFF
--- a/src/middleware/status.js
+++ b/src/middleware/status.js
@@ -1,0 +1,17 @@
+import isFunction from 'lodash/isFunction';
+
+export default (getStatus) => (app) => {
+  const finalGetStatus = isFunction(getStatus) ? getStatus : () => getStatus;
+  return {
+    ...app,
+    request(req, res) {
+      return Promise.resolve(req)
+        .then(finalGetStatus)
+        .then((status) => {
+          status && (res.statusCode = status);
+          app.request(req, res);
+        })
+        .catch((err) => app.error(err, req, res));
+    },
+  };
+};

--- a/test/spec/middleware/status.spec.js
+++ b/test/spec/middleware/status.spec.js
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import status from '../../../src/middleware/status';
+
+describe('status', () => {
+  let res;
+  let req;
+  let next;
+
+  beforeEach(() => {
+    req = {};
+    res = {};
+    next = {
+      request: sinon.spy(),
+      error: sinon.spy(),
+    };
+  });
+
+  it('should call next request', (done) => {
+    const app = status()(next);
+    app.request(req, res).then(() => {
+      expect(next.request).to.be.calledWith(req, res);
+      done();
+    });
+  });
+
+  it('should set res.statusCode', (done) => {
+    const app = status(200)(next);
+    app.request(req, res).then(() => {
+      expect(res.statusCode).to.be.equal(200);
+      done();
+    });
+  });
+
+  it('should call function argument', (done) => {
+    const handler = sinon.spy(() => 200);
+    const app = status(handler)(next);
+    app.request(req, res).then(() => {
+      expect(handler).to.be.calledWith(req);
+      expect(res.statusCode).to.be.equal(200);
+      done();
+    });
+  });
+
+  it('should not set res.statusCode if value is falsy', (done) => {
+    const app = status(false)(next);
+    app.request(req, res).then(() => {
+      expect(res.statusCode).to.be.be.undefined;
+      done();
+    });
+  });
+
+  it('should call next error', (done) => {
+    const err = new Error();
+    const handler = () => {
+      throw err;
+    };
+    const app = status(handler)(next);
+    app.request(req, res).then(() => {
+      expect(next.error).to.be.calledWith(err, req, res);
+      expect(res.statusCode).to.be.be.undefined;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
The argument to `status` can be an int, a promise resolving to an int, or a function that operates on req and returns an int or promise resolving to an int.