### PR TITLE
Make `assets` middleware slightly smarter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "on-finished": "^2.3.0",
     "on-headers": "^1.0.1",
     "useragent": "^2.1.8",
-    "webpack-assets": "^0.1.4",
+    "webpack-assets": "^0.2.0",
     "yamlparser": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
* Use more aptly named env var `HAS_WEBPACK_STATS_EVENTS`.
* Only read assets if they exist, warn only if they're actually needed.
* Upgrade to latest `webpack-assets`.

The `exists` check prevents the development server from crashing when it can't find any assets.