### PR TITLE
Support for matching.

### DIFF
--- a/example/http.js
+++ b/example/http.js
@@ -1,8 +1,8 @@
 /* eslint no-console: 0 */
 import http from 'http';
 import base from '../src/base';
+import connect from '../src/adapter/http';
 
-const server = http.createServer();
 const createApp = base({
   locales: [ 'en-US' ],
 });
@@ -17,7 +17,4 @@ const app = createApp({
   },
 });
 
-server.on('request', app.request);
-server.on('error', app.error);
-
-server.listen(8081);
+connect(app, http.createServer()).listen(8081);

--- a/example/match.js
+++ b/example/match.js
@@ -1,0 +1,26 @@
+/* eslint no-console: 0 */
+import compose from 'lodash/flowRight';
+import http from 'http';
+import send from '../src/middleware/send';
+import match from '../src/middleware/match';
+import path from '../src/middleware/match/path';
+import connect from '../src/adapter/http';
+
+const createApp = compose(
+  match(path('/foo'), send('Hi from foo')),
+  match(path('/bar'), send('Hi from bar'))
+);
+
+const app = createApp({
+  request(req, res) {
+    if (!res.headersSent) {
+      res.statusCode = 404;
+      res.end(`Hello from elsewhere.`);
+    }
+  },
+  error(err) {
+    console.log('GOT ERROR', err);
+  },
+});
+
+connect(app, http.createServer()).listen(8081);

--- a/example/verbs.js
+++ b/example/verbs.js
@@ -1,0 +1,28 @@
+/* eslint no-console: 0 */
+import compose from 'lodash/flowRight';
+import http from 'http';
+import send from '../src/middleware/send';
+import verbs from '../src/middleware/match/verbs';
+import connect from '../src/adapter/http';
+
+console.log(verbs);
+
+const createApp = compose(
+  verbs.get('/foo', send('GET /foo')),
+  verbs.post('/foo', send('POST /foo')),
+  verbs.get('/bar', send('GET /bar'))
+);
+
+const app = createApp({
+  request(req, res) {
+    if (!res.headersSent) {
+      res.statusCode = 404;
+      res.end(`Hello from elsewhere.`);
+    }
+  },
+  error(err) {
+    console.log('GOT ERROR', err);
+  },
+});
+
+connect(app, http.createServer()).listen(8081);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "node-uuid": "^1.4.7",
     "on-finished": "^2.3.0",
     "on-headers": "^1.0.1",
+    "parseurl": "^1.3.1",
+    "path-to-regexp": "^1.2.1",
+    "qs": "^6.0.2",
     "useragent": "^2.1.8",
     "webpack-assets": "^0.2.0",
     "yamlparser": "0.0.2"

--- a/src/adapter/http.js
+++ b/src/adapter/http.js
@@ -1,6 +1,8 @@
 export default function connect(app, server) {
   Object.keys(app).forEach(evt => {
-    server.on(evt, app[evt]);
+    if (typeof app[evt] === 'function') {
+      server.on(evt, app[evt]);
+    }
   });
   return server;
 }

--- a/src/middleware/match.js
+++ b/src/middleware/match.js
@@ -1,0 +1,18 @@
+
+export default function(match, yes, no = (x) => x) {
+  return function(_app) {
+    const app = match(_app);
+    const { request: ya } = yes(app);
+    const { request: na } = no(app);
+    return {
+      ..._app,
+      request(req, res) {
+        if (app.matches(req, res)) {
+          ya(req, res);
+        } else {
+          na(req, res);
+        }
+      },
+    };
+  };
+}

--- a/src/middleware/match/method.js
+++ b/src/middleware/match/method.js
@@ -1,0 +1,4 @@
+import {create} from './util';
+export default (method) => create((req) => {
+  return req.method === method;
+});

--- a/src/middleware/match/path.js
+++ b/src/middleware/match/path.js
@@ -1,0 +1,26 @@
+import url from 'parseurl';
+import {parse, tokensToRegExp} from 'path-to-regexp';
+import {combine} from './util';
+
+export default (path) => (app) => {
+  const tokens = [ ...(app.tokens || []), ...parse(path) ];
+  const regexp = tokensToRegExp(tokens, { end: false });
+  const keys = tokens.filter(t => typeof t === 'object');
+
+  return {
+    ...app,
+    tokens,
+    matches: combine(app, (req) => {
+      const params = regexp.exec(url(req).pathname);
+      if (params) {
+        req.path = params[0];
+        req.params = req.params || {};
+        keys.forEach(({name}, i) => {
+          req.params[name] = params[i + 1];
+        });
+        return true;
+      }
+      return false;
+    }),
+  };
+};

--- a/src/middleware/match/query.js
+++ b/src/middleware/match/query.js
@@ -1,0 +1,8 @@
+import isMatch from 'lodash/isMatch';
+import url from 'parseurl';
+import { parse } from 'qs';
+import {create} from './util';
+
+export default (query) => create((req) => {
+  return isMatch(parse(url(req).query), query);
+});

--- a/src/middleware/match/util.js
+++ b/src/middleware/match/util.js
@@ -1,0 +1,13 @@
+export const combine = (app, match) => {
+  if (!app.matches) {
+    return match;
+  }
+  return (req, res) => app.matches(req, res) && match(req, res);
+};
+
+export const create = (match) => (app) => {
+  return {
+    ...app,
+    matches: combine(app, match),
+  };
+};

--- a/src/middleware/match/verbs.js
+++ b/src/middleware/match/verbs.js
@@ -1,0 +1,17 @@
+import compose from 'lodash/flowRight';
+import http from 'http';
+import method from './method';
+import path from './path';
+import match from '../match';
+
+const verbs = {};
+
+http.METHODS.map(verb => {
+  verbs[verb.toLowerCase()] = (prefix, ...middleware) =>
+    match(compose(method(verb), path(prefix)), compose(...middleware));
+});
+
+verbs.all = (prefix, ...middleware) =>
+  match(path(prefix), compose(...middleware));
+
+export default verbs;

--- a/src/middleware/tap.js
+++ b/src/middleware/tap.js
@@ -1,0 +1,9 @@
+export default (tap) => (app) => {
+  return {
+    ...app,
+    request(req, res) {
+      tap(req, res, app.error);
+      app.request(req, res);
+    },
+  };
+};

--- a/test/script/spec.sh
+++ b/test/script/spec.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-OPTS="-r test/helpers/chai.js -r adana-dump --compilers js:babel-core/register -R spec"
+OPTS="-r test/helpers/chai.js -r adana-dump --compilers js:babel-core/register -R spec --recursive"
 SPECS="test/spec/**/*.spec.js"
 
 # Check for stupid HAPI
@@ -10,4 +10,4 @@ if [ $? -ne 0 ]; then
 fi
 
 set -x
-./node_modules/.bin/_mocha ${OPTS} ${SPECS}
+./node_modules/.bin/_mocha ${OPTS} "${SPECS}"

--- a/test/spec/middleware/match/method.js
+++ b/test/spec/middleware/match/method.js
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import tap from '../../../../src/middleware/tap';
+import match from '../../../../src/middleware/match';
+import method from '../../../../src/middleware/match/method';
+
+describe('method match', () => {
+  it('should handle `if` branch', () => {
+    const yes = sinon.spy();
+    const no = sinon.spy();
+    const next = sinon.spy();
+    const app = match(method('GET'), tap(yes), tap(no))({ request: next });
+
+    app.request({
+      method: 'GET',
+    }, {});
+
+    expect(yes).to.be.calledOnce;
+    expect(no).to.not.be.calledOnce;
+    expect(next).to.be.calledOnce;
+  });
+
+  it('should handle `else` branch', () => {
+    const yes = sinon.spy();
+    const no = sinon.spy();
+    const next = sinon.spy();
+    const app = match(method('GET'), tap(yes), tap(no))({ request: next });
+
+    app.request({
+      method: 'POST',
+    }, {});
+
+    expect(yes).to.not.be.calledOnce;
+    expect(no).to.be.calledOnce;
+    expect(next).to.be.calledOnce;
+  });
+});

--- a/test/spec/middleware/match/path.spec.js
+++ b/test/spec/middleware/match/path.spec.js
@@ -1,0 +1,104 @@
+import compose from 'lodash/flowRight';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import tap from '../../../../src/middleware/tap';
+import match from '../../../../src/middleware/match';
+import path from '../../../../src/middleware/match/path';
+
+describe('path match', () => {
+  it('should handle `if` branch', () => {
+    const yes = sinon.spy();
+    const no = sinon.spy();
+    const next = sinon.spy();
+    const app = match(path('/foo'), tap(yes), tap(no))({ request: next });
+
+    app.request({
+      url: '/foo',
+    }, {});
+
+    expect(yes).to.be.calledOnce;
+    expect(no).to.not.be.calledOnce;
+    expect(next).to.be.calledOnce;
+  });
+
+  it('should handle `else` branch', () => {
+    const yes = sinon.spy();
+    const no = sinon.spy();
+    const next = sinon.spy();
+    const app = match(path('/foo'), tap(yes), tap(no))({ request: next });
+
+    app.request({
+      url: '/bar',
+    }, {});
+
+    expect(yes).to.not.be.calledOnce;
+    expect(no).to.be.calledOnce;
+    expect(next).to.be.calledOnce;
+  });
+
+  it('should handle nested paths', () => {
+    const yes = sinon.spy();
+    const no = sinon.spy();
+    const next = sinon.spy();
+
+    const sub = match(path('/bar'), tap(yes), tap(no));
+
+    const app = match(
+      path('/foo'),
+      sub
+    )({ request: next });
+
+    app.request({
+      url: '/foo/bar',
+    }, {});
+
+    expect(yes).to.be.calledOnce;
+    expect(no).to.not.be.calledOnce;
+    expect(next).to.be.calledOnce;
+  });
+
+  it('should handle path parameters', () => {
+    const yes = sinon.spy();
+    const next = sinon.spy();
+    const app = match(path('/foo/:bar'), tap(yes))({ request: next });
+
+    app.request({
+      url: '/foo/hello',
+    }, {});
+
+    expect(yes).to.be.calledWithMatch(req => req.params.bar === 'hello');
+    expect(next).to.be.calledOnce;
+  });
+
+  it('should handle isolated paths', () => {
+    const yes = sinon.spy();
+    const no = sinon.spy();
+    const next = sinon.spy();
+    const app = compose(
+      match(path('/foo'), tap(yes)),
+      match(path('/bar'), tap(no))
+    )({ request: next });
+
+    app.request({
+      url: '/foo/bar',
+    }, {});
+
+    expect(yes).to.be.calledOnce;
+    expect(no).to.not.be.calledOnce;
+    expect(next).to.be.calledOnce;
+  });
+
+  it('should set the complete matched path', () => {
+    const yes = sinon.spy();
+    const next = sinon.spy();
+    const app = match(path('/foo/:bar/baz'), tap(yes))({ request: next });
+
+    app.request({
+      url: '/foo/hello/baz/qux',
+    }, {});
+
+    expect(yes).to.be.calledWithMatch(req => req.path === '/foo/hello/baz');
+    expect(next).to.be.calledOnce;
+  });
+});

--- a/test/spec/middleware/match/query.spec.js
+++ b/test/spec/middleware/match/query.spec.js
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import tap from '../../../../src/middleware/tap';
+import match from '../../../../src/middleware/match';
+import query from '../../../../src/middleware/match/query';
+
+describe('query match', () => {
+  it('should handle `if` branch', () => {
+    const yes = sinon.spy();
+    const no = sinon.spy();
+    const next = sinon.spy();
+    const app = match(
+      query({ baz: 'world' }),
+      tap(yes),
+      tap(no)
+    )({ request: next });
+
+    app.request({
+      url: '/foo?bar=hello&baz=world',
+    }, {});
+
+    expect(yes).to.be.calledOnce;
+    expect(no).to.not.be.calledOnce;
+    expect(next).to.be.calledOnce;
+  });
+
+  it('should handle `else` branch', () => {
+    const yes = sinon.spy();
+    const no = sinon.spy();
+    const next = sinon.spy();
+    const app = match(
+      query({ baz: 'world', qux: 'hello' }),
+      tap(yes),
+      tap(no)
+    )({ request: next });
+
+    app.request({
+      url: '/foo?bar=hello&baz=world',
+    }, {});
+
+    expect(yes).to.not.be.calledOnce;
+    expect(no).to.be.calledOnce;
+    expect(next).to.be.calledOnce;
+  });
+});

--- a/test/spec/middleware/match/verbs.spec.js
+++ b/test/spec/middleware/match/verbs.spec.js
@@ -1,0 +1,8 @@
+import { expect } from 'chai';
+import verbs from '../../../../src/middleware/match/verbs';
+
+describe('verbs', () => {
+  it('should have some http methods', () => {
+    expect(verbs.get).to.be.an.instanceof(Function);
+  });
+});

--- a/test/spec/middleware/tap.spec.js
+++ b/test/spec/middleware/tap.spec.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import tap from '../../../src/middleware/tap';
+
+describe('tap', () => {
+  it('should call the tap function', () => {
+    const next = sinon.spy();
+    const spy = sinon.spy();
+    const app = tap(spy)({ request: next });
+    const req = 1;
+    const res = 2;
+    app.request(req, res);
+    expect(spy).to.be.calledWith(req, res);
+  });
+
+  it('should continue the chain', () => {
+    const next = sinon.spy();
+    const spy = sinon.spy();
+    const app = tap(spy)({ request: next });
+    const req = 1;
+    const res = 2;
+    app.request(req, res);
+    expect(next).to.be.calledWith(req, res);
+  });
+});


### PR DESCRIPTION
You can now match against urls, query strings, HTTP methods and any other request-based conditional you can think of.

```javascript
const createApp = match(matcher, createIfApp, createElseApp);
```

Creates a new app that:
* if `matcher` passes, the request chain passes to `ifApp`,
* otherwise, the request chain passes to `elseApp`.

The `matcher` is like standard middleware, except instead of returning an object with `request`, it returns an object with `matches(req, res) => boolean` which is used by `matches` to determine which branch to take.

By virtue of the fact `matcher` is (almost) normal middleware, a composition of matchers can be created:

```javascript
const createApp = match(compose(matcherA, matcherB), createIfApp, createElseApp);
```

Standard matchers are available for:
* HTTP methods, e.g. `method('GET')`,
* Paths, e.g. `path('/foo/:bar')`
* Query strings, e.g. `query({ foo: 'bar' })`.

The `path` matcher makes particularly clever use of the standard app composition mechanism – it passes down the path to be matched against to its children, essentially allowing child nodes to determine where they are mounted and to allow child `path` matchers to create combined full path patterns.

All of this has also made it trivial to implement sugar for the standard suite of HTTP-verb matchers that come along with frameworks like `express`:

```javascript
import {get} from 'middleware/match/verbs';
const createApp = get('/foo/:bar', ...);
```

/cc @nealgranger 