### PR TITLE
Add `thunk` middleware.

### DIFF
--- a/example/thunk.js
+++ b/example/thunk.js
@@ -1,0 +1,28 @@
+/* eslint no-console: 0 */
+import compose from 'lodash/flowRight';
+import http from 'http';
+import send from '../src/middleware/send';
+import thunk from '../src/middleware/thunk';
+import connect from '../src/adapter/http';
+
+const createApp = compose(
+  thunk((app) => {
+    const a = send('Hello')(app);
+    const b = send('World')(app);
+    return () => {
+      return (Math.random() > 0.5) ? a : b;
+    };
+  })
+);
+
+const app = createApp({
+  request(req, res) {
+    console.log('UNREACHABLE');
+    res.end();
+  },
+  error(err) {
+    console.log('GOT ERROR', err);
+  },
+});
+
+connect(app, http.createServer()).listen(8081);

--- a/src/middleware/thunk.js
+++ b/src/middleware/thunk.js
@@ -1,0 +1,21 @@
+/**
+ * [default description]
+ * @param {Function} thunkCreator Invoked with `app` to create the thunk. Must
+ * return a function (the thunk) that returns the actual app. This Function
+ * is invoked whenever the app is actually needed (i.e. when any of its event
+ * methods are called, like `request`).
+ * @returns {Function} Middleware function.
+ */
+export default (thunkCreator) => (app) => {
+  const thunk = thunkCreator(app);
+  const thunkApp = {};
+  Object.keys(app).forEach(key => {
+    if (typeof app[key] === 'function') {
+      thunkApp[key] = (...args) => thunk(...args)[key](...args);
+    }
+  });
+  return {
+    ...app,
+    ...thunkApp,
+  };
+};

--- a/test/spec/middleware/thunk.spec.js
+++ b/test/spec/middleware/thunk.spec.js
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import thunk from '../../../src/middleware/thunk';
+
+describe('thunk', () => {
+  it('should use the result of the thunk', () => {
+    const next = sinon.spy();
+    const stub = sinon.spy((app) => () => {
+      return {
+        ...app,
+        request(req, res) {
+          app.request(req, res);
+        },
+      };
+    });
+    const app = thunk(stub)({ request: next });
+    const req = 1;
+    const res = 2;
+    app.request(req, res);
+    expect(stub).to.be.calledOnce;
+  });
+
+  it('should not wrap non-functions', () => {
+    const next = sinon.spy();
+    const stub = sinon.spy((app) => {
+      return () => app;
+    });
+    const app = thunk(stub)({ request: next, foo: null });
+    expect(app).to.have.property('foo', null);
+  });
+});


### PR DESCRIPTION
This is essentially the `apply` method of an applicative.

Sometimes you want to change the processing mechanism of your application at runtime instead of construction time. For example:

```javascript
const app = compose(
  match(path('/foo'), send())
);
```

This app structure is static. That app will always match `/foo` to `send()`. What if we wanted the structure of the app to be the result of a function instead? For example, swapping between a random app per request or using routes from a database? Such a thing is now possible in relatively elegant fashion:

Swapping between two apps:

```javascript
const createApp = compose(
  thunk((app) => {
    const a = send('Hello')(app);
    const b = send('World')(app);
    return () => {
      return (Math.random() > 0.5) ? a : b;
    };
  })
);
```

Updating routes at runtime:

```javascript
const createApp = compose(
  thunk((app) => {
    let result = app;
    db.on('update', (routes) => {
      result = routes.reduce((result, route) => {
        return middlewareForRoute(route)(result);
      }, app);
    });
    return () => result;
  })
);
```

The `thunk` middleware basically defers access to the appropriate method (e.g. `request`, `error`, etc.) to the last possible moment at which point it calls the thunk to get the method at that instant. 

You provide one argument to `thunk` which is your thunk creator: a function that takes, as input, an `app` and returns as output not an app but a _function_ returning an app. This function is then invoked whenever the app is actually needed (i.e. on any of the event calls like `request`).

/cc @nealgranger 