### PR TITLE
Support for `proxy` middleware. 

### DIFF
--- a/example/proxy.js
+++ b/example/proxy.js
@@ -1,0 +1,18 @@
+/* eslint no-console: 0 */
+import http from 'http';
+import proxy from '../src/middleware/proxy';
+import connect from '../src/adapter/http';
+
+const createApp = proxy({ target: 'https://www.google.com', secure: false });
+
+const app = createApp({
+  request(req, res) {
+    res.statusCode = 404;
+    res.end();
+  },
+  error(err) {
+    console.log('GOT ERROR', err);
+  },
+});
+
+connect(app, http.createServer()).listen(8081);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "compression": "^1.6.0",
     "cookies": "^0.5.1",
+    "http-proxy": "^1.12.1",
     "lodash": "^4.0.0",
     "morgan": "^1.6.1",
     "negotiator": "^0.6.0",

--- a/src/middleware/proxy.js
+++ b/src/middleware/proxy.js
@@ -1,0 +1,24 @@
+import Proxy from 'http-proxy';
+
+/**
+TODO: Handle these events:
+proxy.on('proxyReq', (proxyReq, req, res, options) => { });
+proxy.on('proxyRes', (proxyRes, req, res) => { });
+*/
+
+export default function(options) {
+  const proxy = Proxy.createProxy();
+  return (app) => {
+    const { error } = app;
+
+    return {
+      ...app,
+      request(req, res) {
+        proxy.web(req, res, options, err => error(err, req, res));
+      },
+      upgrade(req, socket, head) {
+        proxy.ws(req, socket, head, options, err => error(err, req));
+      },
+    };
+  };
+}

--- a/test/spec/middleware/proxy.spec.js
+++ b/test/spec/middleware/proxy.spec.js
@@ -1,0 +1,38 @@
+import Proxy from 'http-proxy';
+import sinon from 'sinon';
+import {expect} from 'chai';
+
+import proxy from '../../../src/middleware/proxy';
+
+describe('proxy', () => {
+  let sandbox;
+  let server;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(Proxy, 'createProxy').returns(server = {
+      ws: sandbox.stub(),
+      web: sandbox.stub(),
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('shoud call the `web` proxy method on `request`', () => {
+    const spy = sinon.spy();
+    const options = { target: 'http://www.google.ca' };
+    const app = proxy(options)({ request: spy });
+    app.request(1, 2);
+    expect(server.web).to.be.calledWithMatch(1, 2, options);
+  });
+
+  it('shoud call the `ws` proxy method on `upgrade`', () => {
+    const spy = sinon.spy();
+    const options = { target: 'http://www.google.ca' };
+    const app = proxy(options)({ upgrade: spy });
+    app.upgrade(1, 2, 3);
+    expect(server.ws).to.be.calledWith(1, 2, 3, options);
+  });
+});


### PR DESCRIPTION
Now you can pipe requests to other servers. The initial implementation is intentionally simple – you can't adjust anything other than the options passed into the proxy request handler (i.e. `{ target: 'http://www.google.ca'; }`). This will probably change in the future.

/cc @nealgranger 