### PR TITLE
Ignore tokens for path matches against `/`.

### DIFF
--- a/src/middleware/match/path.js
+++ b/src/middleware/match/path.js
@@ -3,7 +3,10 @@ import {parse, tokensToRegExp} from 'path-to-regexp';
 import {combine} from './util';
 
 export default (path) => (app) => {
-  const tokens = [ ...(app.tokens || []), ...parse(path) ];
+  const tokens = [
+    ...(app.tokens || []),
+    ...(path === '/' ? [] : parse(path)),
+  ];
   const regexp = tokensToRegExp(tokens, { end: false });
   const keys = tokens.filter(t => typeof t === 'object');
 

--- a/test/spec/middleware/match/path.spec.js
+++ b/test/spec/middleware/match/path.spec.js
@@ -58,6 +58,27 @@ describe('path match', () => {
     expect(next).to.be.calledOnce;
   });
 
+  it('should handle nested root paths', () => {
+    const yes = sinon.spy();
+    const no = sinon.spy();
+    const next = sinon.spy();
+
+    const sub = match(path('/foo'), tap(yes), tap(no));
+
+    const app = match(
+      path('/'),
+      sub
+    )({ request: next });
+
+    app.request({
+      url: '/foo',
+    }, {});
+
+    expect(yes).to.be.calledOnce;
+    expect(no).to.not.be.calledOnce;
+    expect(next).to.be.calledOnce;
+  });
+
   it('should handle path parameters', () => {
     const yes = sinon.spy();
     const next = sinon.spy();


### PR DESCRIPTION
If `/` remains as a token you end up with a tokens array of `['/', '/foo', ...]` this will only match the path `//foo`. By stripping the tokens if the path is `/` the problem is solved.

/cc @nealgranger 