### PR TITLE
Add redirect middleware.

### DIFF
--- a/src/middleware/redirect.js
+++ b/src/middleware/redirect.js
@@ -1,0 +1,26 @@
+import isFunction from 'lodash/isFunction';
+import isString from 'lodash/isString';
+
+const normalize = (url) => {
+  if (isFunction(url)) {
+    return url;
+  } else if (isString(url)) {
+    return () => url;
+  }
+  throw new TypeError();
+};
+
+export default function(url) {
+  const get = normalize(url);
+  return function(app) {
+    return {
+      ...app,
+      request(req, res) {
+        res.writeHead(302, {
+          Location: get(req, res),
+        });
+        res.end();
+      },
+    };
+  };
+}

--- a/test/spec/middleware/redirect.spec.js
+++ b/test/spec/middleware/redirect.spec.js
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import redirect from '../../../src/middleware/redirect';
+
+describe('redirect', () => {
+  let res;
+  let req;
+  let next;
+
+  beforeEach(() => {
+    req = {};
+    res = {
+      writeHead: sinon.spy(),
+      end: sinon.spy(),
+    };
+    next = {
+      request: sinon.spy(),
+      error: sinon.spy(),
+    };
+  });
+
+  it('should not call next request', () => {
+    const app = redirect('/foo')(next);
+    app.request(req, res);
+    expect(next.request).to.be.not.called;
+    expect(res.end).to.be.calledOnce;
+  });
+
+  it('should set the status code and url', () => {
+    const app = redirect('/foo')(next);
+    app.request(req, res);
+    expect(res.writeHead).to.be.calledWithMatch(302, {
+      Location: '/foo',
+    });
+  });
+
+  it('should set the status code and url for functions', () => {
+    const app = redirect(() => '/foo')(next);
+    app.request(req, res);
+    expect(res.writeHead).to.be.calledWithMatch(302, {
+      Location: '/foo',
+    });
+  });
+
+  it('should fail for invalid parameters', () => {
+    expect(() => {
+      redirect(false);
+    }).to.throw(TypeError);
+  });
+});


### PR DESCRIPTION
Let's you send your users somewhere else! Basically shorthand for setting the HTTP status code, adding a location header and ending the request. Can be invoked with either a function generating the new location or a string.

e.g.

```javascript
redirect(() => '/foo');
```

or

```javascript
redirect('/foo');
```

/cc @nealgranger 